### PR TITLE
Replace project name and arch with dynamic vars(production)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,20 +44,20 @@ compile:
   script:
     - >
       if [ "$BASE_URL" == "https://gitlab.cncf.ci" ]; then
-        echo curl -f -X GET "https://productionapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_PROJECT_NAME}&arch=$ARCH"
-        curl -f -X GET "https://productionapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_PROJECT_NAME}&arch=$ARCH" 
+        echo curl -f -X GET "https://productionapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=${CI_PROJECT_NAME}&ref=${CI_COMMIT_SHA}&arch=$ARCH"
+        curl -f -X GET "https://productionapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=${CI_PROJECT_NAME}&ref=${CI_COMMIT_SHA}&arch=$ARCH" 
 
       elif [ "$BASE_URL" == "https://gitlab.staging.cncf.ci" ]; then
-        echo curl -f -X GET "https://stagingapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_PROJECT_NAME}&arch=$ARCH"
-        curl -f -X GET "https://stagingapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_PROJECT_NAME}&arch=$ARCH" 
+        echo curl -f -X GET "https://stagingapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=${CI_PROJECT_NAME}&ref=${CI_COMMIT_SHA}&arch=$ARCH"
+        curl -f -X GET "https://stagingapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=${CI_PROJECT_NAME}&ref=${CI_COMMIT_SHA}&arch=$ARCH" 
 
       elif [ "$BASE_URL" == "https://gitlab.cidev.cncf.ci" ]; then
-        echo curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_PROJECT_NAME}&arch=$ARCH"
-        curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_PROJECT_NAME}&arch=$ARCH" 
+        echo curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=${CI_PROJECT_NAME}&ref=${CI_COMMIT_SHA}&arch=$ARCH"
+        curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=${CI_PROJECT_NAME}&ref=${CI_COMMIT_SHA}}&arch=$ARCH" 
 
       else
-        echo curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_PROJECT_NAME}&arch=$ARCH"
-        curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_PROJECT_NAME}&arch=$ARCH" 
+        echo curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=${CI_PROJECT_NAME}&ref=${CI_COMMIT_SHA}&arch=$ARCH"
+        curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=${CI_PROJECT_NAME}&ref=${CI_COMMIT_SHA}&arch=$ARCH" 
 
       fi
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,54 +44,25 @@ compile:
   script:
     - >
       if [ "$BASE_URL" == "https://gitlab.cncf.ci" ]; then
-        echo curl -f -X GET "https://productionapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_COMMIT_SHA}&arch=AMD64" 
-        echo curl -f -X GET "https://productionapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_COMMIT_SHA}&arch=ARM64"
-        curl -f -X GET "https://productionapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_COMMIT_SHA}&arch=AMD64" 
-        curl -f -X GET "https://productionapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_COMMIT_SHA}&arch=ARM64" 
+        echo curl -f -X GET "https://productionapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_PROJECT_NAME}&arch=$ARCH"
+        curl -f -X GET "https://productionapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_PROJECT_NAME}&arch=$ARCH" 
 
       elif [ "$BASE_URL" == "https://gitlab.staging.cncf.ci" ]; then
-        echo curl -f -X GET "https://stagingapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_COMMIT_SHA}&arch=AMD64" 
-        echo curl -f -X GET "https://stagingapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_COMMIT_SHA}&arch=ARM64"
-        curl -f -X GET "https://stagingapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_COMMIT_SHA}&arch=AMD64" 
-        curl -f -X GET "https://stagingapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_COMMIT_SHA}&arch=ARM64" 
+        echo curl -f -X GET "https://stagingapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_PROJECT_NAME}&arch=$ARCH"
+        curl -f -X GET "https://stagingapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_PROJECT_NAME}&arch=$ARCH" 
 
       elif [ "$BASE_URL" == "https://gitlab.cidev.cncf.ci" ]; then
-        echo curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_COMMIT_SHA}&arch=AMD64" 
-        echo curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_COMMIT_SHA}&arch=ARM64"
-        curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_COMMIT_SHA}&arch=AMD64" 
-        curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_COMMIT_SHA}&arch=ARM64" 
+        echo curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_PROJECT_NAME}&arch=$ARCH"
+        curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_PROJECT_NAME}&arch=$ARCH" 
 
       else
-        echo curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_COMMIT_SHA}&arch=AMD64" 
-        echo curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_COMMIT_SHA}&arch=ARM64"
-        curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_COMMIT_SHA}&arch=AMD64" 
-        curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_COMMIT_SHA}&arch=ARM64" 
+        echo curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_PROJECT_NAME}&arch=$ARCH"
+        curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=testproj&ref=${CI_PROJECT_NAME}&arch=$ARCH" 
 
       fi
-    - > 
-  artifacts:
-    name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
-    untracked: true
-    expire_in: 4 weeks
-    paths:
-      - "*gem"
-      - "vendor"
-      - Gemfile.lock
 
 container:
   stage: Package
   image: crosscloudci/debian-docker
-  only:
-    variables:
-      - $ARCH == "amd64"
-  dependencies:
-    - compile
   script:
-    - apt update && apt -y install curl jq git make
-
-  artifacts:
-    name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
-    untracked: true
-    expire_in: 4 weeks
-    paths:
-      - release.env
+    - echo 'Dummy Job'


### PR DESCRIPTION
## Description
1. Removes project name hard coding from the gitlab yml. 
Issues:
- crosscloudci/crosscloudci#212 
- vulk/cncf_ci/issues/305

## How Has This Been Tested?
* [x]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [] Tested with [trigger client](https://github.com/crosscloudci/crosscloudci-trigger) against 
   * [] cidev.cncf.ci
   * [x] dev.cncf.ci
   * [x] staging.cncf.ci
   * [ ] cncf.ci (production)
* [x]  Tested locally
* [ ]  Have not tested

## Types of changes
* [x]  Bug fix (non-breaking change which fixes an issue)
* [x]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
## Checklist:
* [ ]  My change requires a change to the documentation.
* [x]  I have updated the documentation accordingly.
* [] No updates required.